### PR TITLE
Updated fetch adapter to use ActiveModel::Serializer::Adapter#create to ...

### DIFF
--- a/grape-active_model_serializers.gemspec
+++ b/grape-active_model_serializers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.add_dependency 'grape'
-  gem.add_dependency 'active_model_serializers', '>= 0.9.0'
+  gem.add_dependency 'active_model_serializers', '>= 0.10.0.rc2'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rack-test'

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -1,43 +1,42 @@
 module Grape
   module Formatter
     module ActiveModelSerializers
-
-      ADAPTER_OPTION_KEYS = [:include, :fields, :root, :adapter]
+      ADAPTER_OPTION_KEYS = [:include, :fields, :adapter]
 
       class << self
         def call(resource, env)
           adapter_options, serializer_options =
               ams_options(env).partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
-          serializer = fetch_serializer(resource, env, serializer_options)
-          adapter = fetch_adapter(serializer, resource, env, adapter_options)
-
+          serialized = fetch_serialized(resource, env, serializer_options)
+          adapter = fetch_adapter(serialized, env, adapter_options)
 
           if adapter
             adapter.serializable_hash.to_json
           else
-            if serializer
-              serializer.object.to_json
+            if serialized
+              serialized.object.to_json
             else
               Grape::Formatter::Json.call resource, env
             end
           end
         end
 
-        def fetch_adapter(serializer, resource, env, ams_options)
-          return nil unless serializer
+        def fetch_adapter(serialized, env, adapter_opts)
+          use_adapter = !(adapter_opts.key?(:adapter) && !adapter_opts[:adapter])
+          return nil unless use_adapter && serialized
 
           endpoint = env['api.endpoint']
-          options = build_adapter_options_from_endpoint(endpoint)
+          options = adapter_options_from_endpoint(endpoint)
 
           adapter = options.fetch(:adapter, ActiveModel::Serializer.config.adapter)
           return nil unless adapter
 
-          ActiveModel::Serializer::Adapter.create(serializer, options.merge(ams_options))
+          ActiveModel::Serializer::Adapter.create(serialized, options.merge(adapter_opts))
         end
 
-        def fetch_serializer(resource, env, ams_options)
+        def fetch_serialized(resource, env, serializer_opts)
           endpoint = env['api.endpoint']
-          options = build_options_from_endpoint(endpoint)
+          options = serializer_options_from_endpoint(endpoint)
 
           serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
           return nil unless serializer
@@ -48,19 +47,29 @@ module Grape
 
           options[:scope] = endpoint unless options.key?(:scope)
           # ensure we have an root to fallback on
-          options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
-          serializer.new(resource, options.merge(ams_options))
+          # options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
+
+          begin
+            serializer.new(resource, options.merge(serializer_opts))
+          rescue # ActiveModel::Serializer::ArraySerializer::NoSerializerError
+            nil
+          end
         end
 
         def ams_options(env)
           env['ams_meta'] || {}
         end
 
-        def build_options_from_endpoint(endpoint)
-          [endpoint.default_serializer_options || {}, endpoint.namespace_options, endpoint.route_options, endpoint.options, endpoint.options.fetch(:route_options)].reduce(:merge)
+        def serializer_options_from_endpoint(endpoint)
+          [endpoint.default_serializer_options || {},
+           endpoint.namespace_options,
+           endpoint.route_options,
+           endpoint.options,
+           endpoint.options.fetch(:route_options)
+          ].reduce(:merge)
         end
 
-        def build_adapter_options_from_endpoint(endpoint)
+        def adapter_options_from_endpoint(endpoint)
           endpoint.default_adapter_options || {}
         end
 

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -36,6 +36,10 @@ module Grape
           serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
           return nil unless serializer
 
+          if options.key?(:each_serializer)
+            options[:serializer] = options.delete :each_serializer
+          end
+
           options[:scope] = endpoint unless options.key?(:scope)
           # ensure we have an root to fallback on
           options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -26,7 +26,7 @@ module Grape
           adapter = options.fetch(:adapter, ActiveModel::Serializer.config.adapter)
           return nil unless adapter
 
-          adapter.new(serializer, options)
+          ActiveModel::Serializer::Adapter.create(serializer, options)
         end
 
         def fetch_serializer(resource, env)

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -19,7 +19,7 @@ describe Grape::Formatter::ActiveModelSerializers do
     end
 
     it 'should read serializer options like "root"' do
-      expect(described_class.build_options_from_endpoint(app.endpoints.first)).to include :root
+      expect(described_class.serializer_options_from_endpoint(app.endpoints.first)).to include :root
     end
   end
 
@@ -44,7 +44,7 @@ describe Grape::Formatter::ActiveModelSerializers do
       end
     end
 
-    subject { described_class.fetch_serializer(user, env) }
+    subject { described_class.fetch_serialized(user, env) }
 
     it { should be_a UserSerializer }
 
@@ -58,7 +58,7 @@ describe Grape::Formatter::ActiveModelSerializers do
     end
 
     it 'should read serializer options like "root"' do
-      expect(described_class.build_options_from_endpoint(endpoint).keys).to include :root
+      expect(described_class.serializer_options_from_endpoint(endpoint).keys).to include :root
     end
   end
 end


### PR DESCRIPTION
...match AMS implementation. This allows adapters to be specified as symbols (or not at all) in the config options.
